### PR TITLE
Removed default bump line in pushrelease workflow

### DIFF
--- a/.github/workflows/pushrelease.yml
+++ b/.github/workflows/pushrelease.yml
@@ -78,7 +78,6 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           WITH_V: true
-          DEFAULT_BUMP: patch
 
       - name: Checkout two
         uses: actions/checkout@v2


### PR DESCRIPTION
# Description

Removed default bump line in pushrelease workflow file so that the correct version number (v0.2.0) is released. For more details on this release, please see #20 and #22 .

# Checklist:

- [x] PR form
  - [x] I have given this pull request an informative title
  - [x] Description above itemizes changes under subtitles, e.g. "## Collection""
  - [x] Package builds on my OS without issues
- [x] PR checks all pass for latest commit
  - [x] Package builds on Mac
  - [x] Package builds on Windows
  - [x] Package builds on Linux
- [x] Documentation
  - [x] Any new or modified functions or data have roxygen style documentation in their .R scripts
  - [x] Any longer functions are commented inline so that it is easier to debug in the future
  - [x] PR description above and the NEWS.md file are aligned
  - [x] DESCRIPTION file version is bumped by the appropriate increment (major, minor, patch)
